### PR TITLE
Dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,12 @@ Welcome to the UnrealYAML Plugin, a Plugin that allows the parsing and emitting 
 	- Iterators
 	- Loading and Saving Files
 - Usable in Blueprint and C++
-- Automatic Parsing to Unreal Struct using the Unreal Reflection System.
+- Automatic Parsing to Unreal Struct using the Unreal Reflection System
+	- `UPROPERTY` support:
+		- Simple scalar values, such as int, float, FString and FText
+		- `TMap` and `TArray`, and nested `USTRUCT`s 
+		- Object references: `TSoftObjectPtr` and `TSubclassOf`
+	- Configurable validation and detailed error reporting.
 
 ### TODO
 - Node into Struct Parsing:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ Welcome to the UnrealYAML Plugin, a Plugin that allows the parsing and emitting 
 		- Simple scalar values, such as int, float, FString and FText
 		- `TMap` and `TArray`, and nested `USTRUCT`s 
 		- Object references: `TSoftObjectPtr` and `TSubclassOf`
-	- Configurable validation and detailed error reporting.
+	- Configurable validation and detailed error reporting. See `FYamlParseIntoOptions`.
+		- Mark `USTRUCT` fields as being required in YAML when parsing.
+		- Fail if the incoming YAML node cannot be interpreted in to a corresponding Unreal type.
+		- Ensuring that string values in YAML map to a value in the appropriate `UENUM`.
 
 ### TODO
 - Node into Struct Parsing:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Welcome to the UnrealYAML Plugin, a Plugin that allows the parsing and emitting 
 ## Features
 - Basic Functionality
 	- Assigment
-	- Convers Conversion to and from most frequently used Unreal Types
+	- Conversion to and from most frequently used Unreal Types
 	- Iterators
 	- Loading and Saving Files
 - Usable in Blueprint and C++
@@ -19,7 +19,6 @@ Welcome to the UnrealYAML Plugin, a Plugin that allows the parsing and emitting 
 - Node into Struct Parsing:
 	- With Blueprint Structs (if possible)
 	- Option to respect case on key values (currently always case insensitive)
-	- Add Map Parsing
 	- Parse Struct into Node (Reverse Direction)
 - Sequences and Maps into TArray\<Node> and TMap\<FString, Node> for Iteration in Blueprints
 - Interfacing with Unreal JSON Plugin?

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Welcome to the UnrealYAML Plugin, a Plugin that allows the parsing and emitting 
 		- Simple scalar values, such as int, float, FString and FText
 		- `TMap` and `TArray`, and nested `USTRUCT`s 
 		- Object references: `TSoftObjectPtr` and `TSubclassOf`
-	- Configurable validation and detailed error reporting. See `FYamlParseIntoOptions`.
+	- Configurable validation and detailed error reporting. See `FYamlParseIntoOptions` (only supported in C++ for now).
 		- Mark `USTRUCT` fields as being required in YAML when parsing.
 		- Fail if the incoming YAML node cannot be interpreted in to a corresponding Unreal type.
 		- Ensuring that string values in YAML map to a value in the appropriate `UENUM`.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Welcome to the UnrealYAML Plugin, a Plugin that allows the parsing and emitting 
 		- Simple scalar values, such as int, float, FString and FText
 		- `TMap` and `TArray`, and nested `USTRUCT`s 
 		- Object references: `TSoftObjectPtr` and `TSubclassOf`
+		- Custom conversions for your own additional types. See `FYamlParseIntoOptions.TypeHandlers`.
 	- Configurable validation and detailed error reporting. See `FYamlParseIntoOptions` (only supported in C++ for now).
 		- Mark `USTRUCT` fields as being required in YAML when parsing.
 		- Fail if the incoming YAML node cannot be interpreted in to a corresponding Unreal type.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Welcome to the UnrealYAML Plugin, a Plugin that allows the parsing and emitting 
 		- Mark `USTRUCT` fields as being required in YAML when parsing.
 		- Fail if the incoming YAML node cannot be interpreted in to a corresponding Unreal type.
 		- Ensuring that string values in YAML map to a value in the appropriate `UENUM`.
+		- Check for any properties in the YAML that don't map onto a property in a `USTRUCT`.
 
 ### TODO
 - Node into Struct Parsing:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Welcome to the UnrealYAML Plugin, a Plugin that allows the parsing and emitting 
 		- Object references: `TSoftObjectPtr` and `TSubclassOf`
 		- Custom conversions for your own additional types. See `FYamlParseIntoOptions.TypeHandlers`.
 	- Configurable validation and detailed error reporting. See `FYamlParseIntoOptions` (only supported in C++ for now).
-		- Mark `USTRUCT` fields as being required in YAML when parsing.
+		- Mark `USTRUCT` fields as being required in YAML when parsing: `UPROPERTY(meta=YamlRequired)`.
 		- Fail if the incoming YAML node cannot be interpreted in to a corresponding Unreal type.
 		- Ensuring that string values in YAML map to a value in the appropriate `UENUM`.
 		- Check for any properties in the YAML that don't map onto a property in a `USTRUCT`.

--- a/Source/UnrealYAML/Private/Parsing.cpp
+++ b/Source/UnrealYAML/Private/Parsing.cpp
@@ -4,6 +4,43 @@
 DEFINE_LOG_CATEGORY(LogYamlParsing)
 
 
+FYamlParseIntoOptions FYamlParseIntoOptions::StrictParsing() {
+    FYamlParseIntoOptions Ret;
+    Ret.TypeChecking = true;
+    return Ret;
+}
+
+FYamlParseIntoCtx& FYamlParseIntoCtx::PushStack(const TCHAR* Property) {
+    Stack.Add(Property);
+    return *this;
+}
+
+FYamlParseIntoCtx& FYamlParseIntoCtx::PushStack(const FYamlNode& Key) {
+    Stack.Add(Key.Scalar());
+    return *this;
+}
+
+FYamlParseIntoCtx& FYamlParseIntoCtx::PushStack(const int32 Index) {
+    Stack.Add(FString::Printf(TEXT("[%d]"), Index));
+    return *this;
+}
+
+void FYamlParseIntoCtx::PopStack() {
+    Stack.RemoveAt(Stack.Num() - 1);
+}
+
+void FYamlParseIntoCtx::AddError(const TCHAR* Err) {
+    Errors.Add(FString::Printf(TEXT("%s: %s"), *StackStr(), Err));
+}
+
+bool FYamlParseIntoCtx::Success() const {
+    return Errors.Num() == 0;
+}
+
+FString FYamlParseIntoCtx::StackStr() const {
+    return FString::Join(Stack, TEXT("."));
+}
+
 // Parsing into/from Files ---------------------------------------------------------------------------------------------
 bool UYamlParsing::ParseYaml(const FString String, FYamlNode& Out) {
     try {
@@ -31,7 +68,7 @@ void UYamlParsing::WriteYamlToFile(const FString Path, const FYamlNode Node) {
 const TArray<FString> UYamlParsing::NativeTypes = {"FString", "FText", "FVector", "FQuat", "FTransform", "FColor",
                                                    "FLinearColor"};
 
-bool UYamlParsing::ParseIntoProperty(const FYamlNode& Node, const FProperty& Property, void* PropertyValue) {
+bool UYamlParsing::ParseIntoProperty(const FYamlNode& Node, const FProperty& Property, void* PropertyValue, FYamlParseIntoCtx& Ctx) {
     UE_LOG(LogYamlParsing, Verbose, TEXT("Parsing Node into Property '%s' of type '%s'"), *Property.GetName(),
            *Property.GetCPPType())
 
@@ -42,65 +79,102 @@ bool UYamlParsing::ParseIntoProperty(const FYamlNode& Node, const FProperty& Pro
 
     if (const FNumericProperty* NumericProperty = CastField<FNumericProperty>(&Property)) {
         if (NumericProperty->IsInteger()) {
+            if (!CheckScalarCanConvert<uint64>(Ctx, TEXT("integer"), Node)) {
+                return false;
+            }
+
             const auto Value = Node.AsOptional<uint64>();
             if (Value.IsSet()) {
                 NumericProperty->SetIntPropertyValue(PropertyValue, Value.GetValue());
             }
         } else {
+            if (!CheckScalarCanConvert<float>(Ctx, TEXT("float"), Node)) {
+                return false;
+            }
+
             const auto Value = Node.AsOptional<float>();
             if (Value.IsSet()) {
                 NumericProperty->SetFloatingPointPropertyValue(PropertyValue, Value.GetValue());
             }
         }
     } else if (const FBoolProperty* BoolProperty = CastField<FBoolProperty>(&Property)) {
+        if (!CheckScalarCanConvert<bool>(Ctx, TEXT("bool"), Node)) {
+            return false;
+        }
+
         const auto Value = Node.AsOptional<bool>();
         if (Value.IsSet()) {
             BoolProperty->SetPropertyValue(PropertyValue, Value.GetValue());
         }
     } else if (const FStrProperty* StringProperty = CastField<FStrProperty>(&Property)) {
+        if (!CheckScalarCanConvert<FString>(Ctx, TEXT("string"), Node)) {
+            return false;
+        }
+
         const auto Value = Node.AsOptional<FString>();
         if (Value.IsSet()) {
             *const_cast<FString*>(&StringProperty->GetPropertyValue(PropertyValue)) = Value.GetValue();
         }
     } else if (const FTextProperty* TextProperty = CastField<FTextProperty>(&Property)) {
+        if (!CheckScalarCanConvert<FText>(Ctx, TEXT("string"), Node)) {
+            return false;
+        }
+
         const auto Value = Node.AsOptional<FText>();
         if (Value.IsSet()) {
             *const_cast<FText*>(&TextProperty->GetPropertyValue(PropertyValue)) = Value.GetValue();
         }
     } else if (const FEnumProperty* EnumProperty = CastField<FEnumProperty>(&Property)) {
+        // TODO: Validate.
         const int64 Index = EnumProperty->GetEnum()->GetIndexByNameString(Node.As<FString>());
         EnumProperty->GetUnderlyingProperty()->SetIntPropertyValue(PropertyValue, Index);
     } else if (const FArrayProperty* ArrayProperty = CastField<FArrayProperty>(&Property)) {
+        if (!CheckNodeType(Ctx, EYamlNodeType::Sequence, TEXT("sequence"), Node)) {
+            return false;
+        }
+
         // We need the helper to get to the items of the array            
         FScriptArrayHelper Helper(ArrayProperty, PropertyValue);
         Helper.AddValues(Node.Size());
 
         bool ParsedAllProperties = true;
         for (int32 i = 0; i < Helper.Num(); ++i) {
-            if (!ParseIntoProperty(Node[i], *ArrayProperty->Inner, Helper.GetRawPtr(i))) {
+            if (!ParseIntoProperty(Node[i], *ArrayProperty->Inner, Helper.GetRawPtr(i), Ctx.PushStack(i))) {
                 ParsedAllProperties = false;
             }
+
+            Ctx.PopStack();
         }
 
         return ParsedAllProperties;
     } else if (const FObjectProperty* ObjectProperty = CastField<FObjectProperty>(&Property)) {
-        return ParseIntoObject(Node, ObjectProperty->PropertyClass, PropertyValue);
+        auto Ret = ParseIntoObject(Node, ObjectProperty->PropertyClass, PropertyValue, Ctx);
+        return Ret;
     } else if (const FStructProperty* StructProperty = CastField<FStructProperty>(&Property)) {
-        return ParseIntoStruct(Node, StructProperty->Struct, PropertyValue);
+        auto Ret = ParseIntoStruct(Node, StructProperty->Struct, PropertyValue, Ctx);
+        return Ret;
     } else if (const FMapProperty* MapProperty = CastField<FMapProperty>(&Property)) {
+        if (!CheckNodeType(Ctx, EYamlNodeType::Map, TEXT("map"), Node)) {
+            return false;
+        }
+
         FScriptMapHelper Helper(MapProperty, PropertyValue);
 
         bool ParsedAllProperties = true;
         for(auto It=Node.begin(); It != Node.end(); ++It) {
             const auto i = Helper.AddDefaultValue_Invalid_NeedsRehash();
 
-            if (!ParseIntoProperty((*It).Key, *Helper.KeyProp, Helper.GetKeyPtr(i))) {
+            Ctx.PushStack((*It).Key);
+
+            if (!ParseIntoProperty((*It).Key, *Helper.KeyProp, Helper.GetKeyPtr(i), Ctx)) {
                 ParsedAllProperties = false;
             }
 
-            if (!ParseIntoProperty((*It).Value, *Helper.ValueProp, Helper.GetValuePtr(i))) {
+            if (!ParseIntoProperty((*It).Value, *Helper.ValueProp, Helper.GetValuePtr(i), Ctx)) {
                 ParsedAllProperties = false;
             }
+
+            Ctx.PopStack();
         }
 
         Helper.Rehash();
@@ -111,39 +185,53 @@ bool UYamlParsing::ParseIntoProperty(const FYamlNode& Node, const FProperty& Pro
     return true;
 }
 
-bool UYamlParsing::ParseIntoObject(const FYamlNode& Node, const UClass* Object, void* ObjectValue) {
+bool UYamlParsing::ParseIntoObject(const FYamlNode& Node, const UClass* Object, void* ObjectValue, FYamlParseIntoCtx& Ctx) {
     UE_LOG(LogYamlParsing, Verbose, TEXT("Parsing Node into Object '%s'"), *Object->GetName())
+
+    if (!CheckNodeType(Ctx, EYamlNodeType::Map, TEXT("map"), Node)) {
+        return false;
+    }
 
     bool ParsedAllProperties = true;
     for (TFieldIterator<FProperty> It(Object); It; ++It) {
         FString Key = It->GetName();
-        if (!ParseIntoProperty(Node[Key], **It, It->ContainerPtrToValuePtr<void>(ObjectValue))) {
+        if (!ParseIntoProperty(Node[Key], **It, It->ContainerPtrToValuePtr<void>(ObjectValue), Ctx.PushStack(*Key))) {
             ParsedAllProperties = false;
         }
+
+        Ctx.PopStack();
     }
 
     return ParsedAllProperties;
 }
 
-bool UYamlParsing::ParseIntoStruct(const FYamlNode& Node, const UScriptStruct* Struct, void* StructValue) {
+bool UYamlParsing::ParseIntoStruct(const FYamlNode& Node, const UScriptStruct* Struct, void* StructValue, FYamlParseIntoCtx& Ctx) {
     UE_LOG(LogYamlParsing, Verbose, TEXT("Parsing Node into Struct '%s'"), *Struct->GetName())
 
-    if (NativeTypes.Contains(Struct->GetStructCPPName())) {
-        return ParseIntoNativeType(Node, Struct, StructValue);
+    if (!CheckNodeType(Ctx, EYamlNodeType::Map, TEXT("map"), Node)) {
+        return false;
     }
+
+    if (NativeTypes.Contains(Struct->GetStructCPPName())) {
+        return ParseIntoNativeType(Node, Struct, StructValue, Ctx);
+    }
+
+    // TODO: Check all YAML keys are consumed.
 
     bool ParsedAllProperties = true;
     for (TFieldIterator<FProperty> It(Struct); It; ++It) {
         FString Key = It->GetName();
-        if (!ParseIntoProperty(Node[Key], **It, It->ContainerPtrToValuePtr<void>(StructValue))) {
+        if (!ParseIntoProperty(Node[Key], **It, It->ContainerPtrToValuePtr<void>(StructValue), Ctx.PushStack(*Key))) {
             ParsedAllProperties = false;
         }
+
+        Ctx.PopStack();
     }
 
     return ParsedAllProperties;
 }
 
-bool UYamlParsing::ParseIntoNativeType(const FYamlNode& Node, const UScriptStruct* Struct, void* StructValue) {
+bool UYamlParsing::ParseIntoNativeType(const FYamlNode& Node, const UScriptStruct* Struct, void* StructValue, FYamlParseIntoCtx& Ctx) {
     const FString Type = Struct->GetStructCPPName();
 
     if (Type == "FString") {
@@ -162,6 +250,16 @@ bool UYamlParsing::ParseIntoNativeType(const FYamlNode& Node, const UScriptStruc
         *static_cast<FLinearColor*>(StructValue) = Node.As<FLinearColor>();
     } else {
         checkf(false, TEXT("No native type conversion for %s"), *Type)
+        return false;
+    }
+
+    return true;
+}
+
+bool UYamlParsing::CheckNodeType(FYamlParseIntoCtx& Ctx, const EYamlNodeType Expected, const TCHAR* TypeName,
+    const FYamlNode& Node) {
+    if (Ctx.Options.TypeChecking && Node.IsDefined() && Node.Type() != Expected) {
+        Ctx.AddError(*FString::Printf(TEXT("value is not a %s"), TypeName));
         return false;
     }
 

--- a/Source/UnrealYAML/Private/Parsing.cpp
+++ b/Source/UnrealYAML/Private/Parsing.cpp
@@ -271,7 +271,13 @@ bool UYamlParsing::ParseIntoStruct(const FYamlNode& Node, const UScriptStruct* S
 
         Ctx.PushStack(*Key);
 
-        if (It->HasMetaData(YamlRequiredSpecifier) && !Node[Key].IsDefined()) {
+        bool IsRequired = false;
+#if WITH_EDITORONLY_DATA
+        // UPROPERTY metadata is not available outside of the editor.
+        IsRequired = It->HasMetaData(YamlRequiredSpecifier);
+#endif
+
+        if (IsRequired && !Node[Key].IsDefined()) {
             Ctx.AddError(TEXT("yaml does not contain this required field"));
         } else if (!ParseIntoProperty(Node[Key], **It, It->ContainerPtrToValuePtr<void>(StructValue), Ctx)) {
             ParsedAllProperties = false;

--- a/Source/UnrealYAML/Private/Parsing.cpp
+++ b/Source/UnrealYAML/Private/Parsing.cpp
@@ -249,6 +249,12 @@ bool UYamlParsing::ParseIntoObject(const FYamlNode& Node, const UClass* Object, 
 bool UYamlParsing::ParseIntoStruct(const FYamlNode& Node, const UScriptStruct* Struct, void* StructValue, FYamlParseIntoCtx& Ctx) {
     UE_LOG(LogYamlParsing, Verbose, TEXT("Parsing Node into Struct '%s'"), *Struct->GetName())
 
+    // Check for custom handlers provided in options first.
+    if (const auto CustomHandler = Ctx.Options.TypeHandlers.Find(Struct->GetStructCPPName()); CustomHandler != nullptr) {
+        (*CustomHandler)(Node, Struct, StructValue, Ctx);
+        return true;
+    }
+
     if (NativeTypes.Contains(Struct->GetStructCPPName())) {
         return ParseIntoNativeType(Node, Struct, StructValue, Ctx);
     }

--- a/Source/UnrealYAML/Private/Parsing.cpp
+++ b/Source/UnrealYAML/Private/Parsing.cpp
@@ -142,6 +142,9 @@ bool UYamlParsing::ParseIntoProperty(const FYamlNode& Node, const FProperty& Pro
 
         // We need the helper to get to the items of the array
         FScriptArrayHelper Helper(ArrayProperty, PropertyValue);
+
+        Helper.EmptyValues(); // Remove any values in the array already.
+
         Helper.AddValues(Node.Size());
 
         bool ParsedAllProperties = true;
@@ -166,6 +169,7 @@ bool UYamlParsing::ParseIntoProperty(const FYamlNode& Node, const FProperty& Pro
         }
 
         FScriptMapHelper Helper(MapProperty, PropertyValue);
+        Helper.EmptyValues(); // Remove any values in the map already.
 
         bool ParsedAllProperties = true;
         for(auto It=Node.begin(); It != Node.end(); ++It) {

--- a/Source/UnrealYAML/Private/Parsing.cpp
+++ b/Source/UnrealYAML/Private/Parsing.cpp
@@ -188,11 +188,9 @@ bool UYamlParsing::ParseIntoProperty(const FYamlNode& Node, const FProperty& Pro
             *const_cast<TObjectPtr<UObject>*>(&ClassProperty->GetPropertyValue(PropertyValue)) = FoundClass;
         }
     } else if (const FObjectProperty* ObjectProperty = CastField<FObjectProperty>(&Property)) {
-        auto Ret = ParseIntoObject(Node, ObjectProperty->PropertyClass, PropertyValue, Ctx);
-        return Ret;
+        return ParseIntoObject(Node, ObjectProperty->PropertyClass, PropertyValue, Ctx);
     } else if (const FStructProperty* StructProperty = CastField<FStructProperty>(&Property)) {
-        auto Ret = ParseIntoStruct(Node, StructProperty->Struct, PropertyValue, Ctx);
-        return Ret;
+        return ParseIntoStruct(Node, StructProperty->Struct, PropertyValue, Ctx);
     } else if (const FMapProperty* MapProperty = CastField<FMapProperty>(&Property)) {
         if (!CheckNodeType(Ctx, EYamlNodeType::Map, TEXT("map"), Node)) {
             return false;

--- a/Source/UnrealYAML/Private/Parsing.cpp
+++ b/Source/UnrealYAML/Private/Parsing.cpp
@@ -164,7 +164,7 @@ bool UYamlParsing::ParseIntoProperty(const FYamlNode& Node, const FProperty& Pro
 
         const auto Value = Node.AsOptional<FString>();
         if (Value.IsSet()) {
-            auto Object = StaticFindObject(UObject::StaticClass(), FSoftObjectPath(Value.GetValue()).GetAssetPath(), false);
+            auto Object = FindObject<UObject>(Value.GetValue());
             if (!IsValid(Object)) {
                 Ctx.AddError(*FString::Printf(TEXT("Cannot find object: %s"), *Value.GetValue()));
                 return false;
@@ -179,8 +179,7 @@ bool UYamlParsing::ParseIntoProperty(const FYamlNode& Node, const FProperty& Pro
 
         const auto Value = Node.AsOptional<FString>();
         if (Value.IsSet()) {
-            auto FoundClass = StaticLoadClass(UObject::StaticClass(), nullptr, *Value.GetValue());
-
+            auto FoundClass = FindClass(Value.GetValue());
             if (!IsValid(FoundClass)) {
                 Ctx.AddError(*FString::Printf(TEXT("Cannot find class: %s"), *Value.GetValue()));
                 return false;

--- a/Source/UnrealYAML/Private/Parsing.cpp
+++ b/Source/UnrealYAML/Private/Parsing.cpp
@@ -90,11 +90,11 @@ bool UYamlParsing::ParseIntoProperty(const FYamlNode& Node, const FProperty& Pro
         }
     } else if (const FNumericProperty* NumericProperty = CastField<FNumericProperty>(&Property)) {
         if (NumericProperty->IsInteger()) {
-            if (!CheckScalarCanConvert<uint64>(Ctx, TEXT("integer"), Node)) {
+            if (!CheckScalarCanConvert<int64>(Ctx, TEXT("integer"), Node)) {
                 return false;
             }
 
-            const auto Value = Node.AsOptional<uint64>();
+            const auto Value = Node.AsOptional<int64>();
             if (Value.IsSet()) {
                 NumericProperty->SetIntPropertyValue(PropertyValue, Value.GetValue());
             }

--- a/Source/UnrealYAML/Private/Parsing.cpp
+++ b/Source/UnrealYAML/Private/Parsing.cpp
@@ -9,6 +9,7 @@ FYamlParseIntoOptions FYamlParseIntoOptions::Strict() {
     Ret.CheckTypes = true;
     Ret.CheckEnums = true;
     Ret.CheckRequired = true;
+    Ret.CheckAdditionalProperties = true;
     return Ret;
 }
 
@@ -256,7 +257,7 @@ bool UYamlParsing::ParseIntoStruct(const FYamlNode& Node, const UScriptStruct* S
         return false;
     }
 
-    // TODO: Check all YAML keys are consumed.
+    auto RemainingKeys = Node.Keys<FString>().Array();
 
     bool ParsedAllProperties = true;
     for (TFieldIterator<FProperty> It(Struct); It; ++It) {
@@ -270,7 +271,24 @@ bool UYamlParsing::ParseIntoStruct(const FYamlNode& Node, const UScriptStruct* S
             ParsedAllProperties = false;
         }
 
+        const auto MatchingKey = RemainingKeys.IndexOfByPredicate([&Key](const FString& Element) {
+            // Note we use == operator here to parallel how yaml-cpp finds keys internally.
+            // For FString, this is a case-insensitive match.
+            return Element == Key;
+        });
+        if (MatchingKey != INDEX_NONE) {
+            RemainingKeys.RemoveAt(MatchingKey);
+        }
+
         Ctx.PopStack();
+    }
+
+    if (Ctx.Options.CheckAdditionalProperties && RemainingKeys.Num()) {
+        for (const auto Key : RemainingKeys) {
+            Ctx.PushStack(*Key);
+            Ctx.AddError(TEXT("additional property not match a property in USTRUCT"));
+            Ctx.PopStack();
+        }
     }
 
     return ParsedAllProperties;

--- a/Source/UnrealYAML/Private/Parsing.cpp
+++ b/Source/UnrealYAML/Private/Parsing.cpp
@@ -292,7 +292,7 @@ bool UYamlParsing::ParseIntoStruct(const FYamlNode& Node, const UScriptStruct* S
     if (Ctx.Options.CheckAdditionalProperties && RemainingKeys.Num()) {
         for (const auto Key : RemainingKeys) {
             Ctx.PushStack(*Key);
-            Ctx.AddError(TEXT("additional property not match a property in USTRUCT"));
+            Ctx.AddError(TEXT("additional property does not match a property in USTRUCT"));
             Ctx.PopStack();
         }
     }

--- a/Source/UnrealYAML/Private/Parsing.cpp
+++ b/Source/UnrealYAML/Private/Parsing.cpp
@@ -219,12 +219,12 @@ bool UYamlParsing::ParseIntoObject(const FYamlNode& Node, const UClass* Object, 
 bool UYamlParsing::ParseIntoStruct(const FYamlNode& Node, const UScriptStruct* Struct, void* StructValue, FYamlParseIntoCtx& Ctx) {
     UE_LOG(LogYamlParsing, Verbose, TEXT("Parsing Node into Struct '%s'"), *Struct->GetName())
 
-    if (!CheckNodeType(Ctx, EYamlNodeType::Map, TEXT("map"), Node)) {
-        return false;
-    }
-
     if (NativeTypes.Contains(Struct->GetStructCPPName())) {
         return ParseIntoNativeType(Node, Struct, StructValue, Ctx);
+    }
+
+    if (!CheckNodeType(Ctx, EYamlNodeType::Map, TEXT("map"), Node)) {
+        return false;
     }
 
     // TODO: Check all YAML keys are consumed.

--- a/Source/UnrealYAML/Private/Parsing.cpp
+++ b/Source/UnrealYAML/Private/Parsing.cpp
@@ -66,8 +66,8 @@ void UYamlParsing::WriteYamlToFile(const FString Path, const FYamlNode Node) {
 
 
 // Parsing into Structs ------------------------------------------------------------------------------------------------
-const TArray<FString> UYamlParsing::NativeTypes = {"FString", "FText", "FVector", "FQuat", "FTransform", "FColor",
-                                                   "FLinearColor"};
+const TArray<FString> UYamlParsing::NativeTypes = {"FString", "FText", "FVector", "FVector2D", "FQuat", "FTransform", "FColor",
+                                                   "FLinearColor", "FRotator"};
 
 bool UYamlParsing::ParseIntoProperty(const FYamlNode& Node, const FProperty& Property, void* PropertyValue, FYamlParseIntoCtx& Ctx) {
     UE_LOG(LogYamlParsing, Verbose, TEXT("Parsing Node into Property '%s' of type '%s'"), *Property.GetName(),
@@ -253,12 +253,16 @@ bool UYamlParsing::ParseIntoNativeType(const FYamlNode& Node, const UScriptStruc
         *static_cast<FVector*>(StructValue) = Node.As<FVector>();
     } else if (Type == "FQuat") {
         *static_cast<FQuat*>(StructValue) = Node.As<FQuat>();
+    } else if (Type == "FRotator") {
+        *static_cast<FRotator*>(StructValue) = Node.As<FQuat>().Rotator();
     } else if (Type == "FTransform") {
         *static_cast<FTransform*>(StructValue) = Node.As<FTransform>();
     } else if (Type == "FColor") {
         *static_cast<FColor*>(StructValue) = Node.As<FColor>();
     } else if (Type == "FLinearColor") {
         *static_cast<FLinearColor*>(StructValue) = Node.As<FLinearColor>();
+    } else if (Type == "FVector2D") {
+        *static_cast<FVector2D*>(StructValue) = Node.As<FVector2D>();
     } else {
         checkf(false, TEXT("No native type conversion for %s"), *Type)
         return false;

--- a/Source/UnrealYAML/Private/Tests/ConvertToStruct.cpp
+++ b/Source/UnrealYAML/Private/Tests/ConvertToStruct.cpp
@@ -401,6 +401,30 @@ softObjectPtr: "not a uobject"
         TestEqual("NegativeInteger Value", Struct.Int, -1);
     }
 
+    // Tests that the YamlRequired meta flag rejects missing YAML.
+    {
+        const auto Yaml = TEXT("optional: 13");
+
+        AssertInvalidParseInto<FRequiredFieldsStruct>(Yaml, TEXT("Required: missing"), this, {
+            ".Required: yaml does not contain this required field"
+        });
+    }
+
+    // Tests that the YamlRequired meta flag passes if present.
+    {
+        const auto Yaml = TEXT("{ optional: 13, required: -1 }");
+        FYamlNode Node;
+        UYamlParsing::ParseYaml(Yaml, Node);
+
+        FRequiredFieldsStruct Struct;
+        FYamlParseIntoCtx Result;
+        ParseNodeIntoStruct(Node, Struct, Result, FYamlParseIntoOptions::Strict());
+
+        TestTrue("Required: present", Result.Success());
+        TestEqual("Required: present required value", Struct.Required, -1);
+        TestEqual("Required: present optional value", Struct.Optional, 13);
+    }
+
     return !HasAnyErrors();
 }
 

--- a/Source/UnrealYAML/Private/Tests/ConvertToStruct.cpp
+++ b/Source/UnrealYAML/Private/Tests/ConvertToStruct.cpp
@@ -330,6 +330,20 @@ text: this is some text
         TestEqual("Text", Struct.Text.ToString(), "this is some text");
     }
 
+    // Tests negative integers are parsed.
+    {
+        const auto Yaml = TEXT("int: -1");
+        FYamlNode Node;
+        UYamlParsing::ParseYaml(Yaml, Node);
+
+        FSimpleStruct Struct;
+        FYamlParseIntoCtx Result;
+        ParseNodeIntoStruct(Node, Struct, Result, FYamlParseIntoOptions::Strict());
+
+        TestTrue("NegativeInteger", Result.Success());
+        TestEqual("NegativeInteger Value", Struct.Int, -1);
+    }
+
     return !HasAnyErrors();
 }
 

--- a/Source/UnrealYAML/Private/Tests/ConvertToStruct.cpp
+++ b/Source/UnrealYAML/Private/Tests/ConvertToStruct.cpp
@@ -28,11 +28,86 @@ bool ConvertToStruct::RunTest(const FString& Parameters) {
 
         uint8* StructData = (uint8*)FMemory::Malloc(FSimpleStruct::StaticStruct()->GetStructureSize());
         FSimpleStruct::StaticStruct()->InitializeDefaultValue(StructData);
-        TestTrue("Parse Node into dynamic SimpleStruct", UYamlParsing::ParseIntoStruct(Node, FSimpleStruct::StaticStruct(), StructData));
+        TestTrue("Parse Node into dynamic SimpleStruct", ParseNodeIntoStruct(Node, FSimpleStruct::StaticStruct(), StructData));
 
         FSimpleStruct* Struct = reinterpret_cast<FSimpleStruct*>(StructData);
         AssertSimpleStructValues(this, *Struct);
         FSimpleStruct::StaticStruct()->DestroyStruct(StructData);
+    }
+
+    // Invalid data.
+    {
+        const FString InvalidYaml(R"yaml(
+str: A String
+int: "not an int"
+bool: {not: a bool}
+arr: {not: an array}
+map:  [1, 2, 3]
+)yaml");
+
+        FYamlNode Node;
+        UYamlParsing::ParseYaml(InvalidYaml, Node);
+
+        FSimpleStruct Struct;
+        FYamlParseIntoCtx Result;
+        ParseNodeIntoStruct(Node, Struct, Result, FYamlParseIntoOptions::StrictParsing());
+
+        TestFalse("Invalid data: failed", Result.Success());
+        if (TestEqual("Invalid data: errors length", Result.Errors.Num(), 4)) {
+            TestEqual("Invalid data: errors[0]", Result.Errors[0], TEXT(".Int: cannot convert \"not an int\" to type integer"));
+            TestEqual("Invalid data: errors[1]", Result.Errors[1], TEXT(".Bool: value is not a scalar"));
+            TestEqual("Invalid data: errors[2]", Result.Errors[2], TEXT(".Arr: value is not a sequence"));
+            TestEqual("Invalid data: errors[3]", Result.Errors[3], TEXT(".Map: value is not a map"));
+        }
+    }
+
+    // Lax parsing of invalid data (default behaviour).
+    {
+        auto InvalidYaml = TEXT(R"yaml(
+str: foo
+int: not an int
+bool: somevalue
+arr: notarray
+map: notmap
+)yaml");
+
+        FYamlNode Node;
+        UYamlParsing::ParseYaml(InvalidYaml, Node);
+
+        FSimpleStruct Struct;
+        TestTrue(TEXT("Invalid data: lax parsing ok"), ParseNodeIntoStruct(Node, Struct));
+    }
+
+    // Invalid parent child.
+    {
+        FString InvalidParentChildYaml(R"yaml(
+embedded:
+    somevalues: {}
+    afloat: foobar
+children:
+    - notanobject
+mappedchildren:
+    value1: [1, 2, 3]
+    value3: 13
+)yaml");
+
+        FYamlNode Node;
+        UYamlParsing::ParseYaml(InvalidParentChildYaml, Node);
+
+        FParentStruct Struct;
+        FYamlParseIntoCtx Result;
+        ParseNodeIntoStruct(Node, Struct, Result, FYamlParseIntoOptions::StrictParsing());
+
+        TestFalse("Invalid parent child: failed", Result.Success());
+        if (TestEqual("Invalid parent child: errors length", Result.Errors.Num(), 7)) {
+            TestEqual("Invalid parent child: errors[0]", Result.Errors[0], TEXT(".Embedded.SomeValues: value is not a sequence"));
+            TestEqual("Invalid parent child: errors[1]", Result.Errors[1], TEXT(".Embedded.AFloat: cannot convert \"foobar\" to type float"));
+            TestEqual("Invalid parent child: errors[2]", Result.Errors[2], TEXT(".Children.[0]: value is not a map"));
+            TestEqual("Invalid parent child: errors[3]", Result.Errors[3], TEXT(".MappedChildren.value1: cannot convert \"value1\" to type integer"));
+            TestEqual("Invalid parent child: errors[4]", Result.Errors[4], TEXT(".MappedChildren.value1: value is not a map"));
+            TestEqual("Invalid parent child: errors[5]", Result.Errors[5], TEXT(".MappedChildren.value3: cannot convert \"value3\" to type integer"));
+            TestEqual("Invalid parent child: errors[6]", Result.Errors[6], TEXT(".MappedChildren.value3: value is not a map"));
+        }
     }
 
     return !HasAnyErrors();

--- a/Source/UnrealYAML/Private/Tests/ConvertToStruct.cpp
+++ b/Source/UnrealYAML/Private/Tests/ConvertToStruct.cpp
@@ -437,7 +437,7 @@ randomprop: [1, 2, 3]
 )yaml");
 
         AssertInvalidParseInto<FSimpleStruct>(Yaml, TEXT("Additional properties"), this, {
-            ".randomprop: additional property not match a property in USTRUCT"
+            ".randomprop: additional property does not match a property in USTRUCT"
         });
     }
 

--- a/Source/UnrealYAML/Private/Tests/ConvertToStruct.cpp
+++ b/Source/UnrealYAML/Private/Tests/ConvertToStruct.cpp
@@ -425,6 +425,22 @@ softObjectPtr: "not a uobject"
         TestEqual("Required: present optional value", Struct.Optional, 13);
     }
 
+    // When the YAML provides additional properties.
+    {
+        const auto Yaml = TEXT(R"yaml(
+str: "foo"
+INT: 13
+bOOl: false
+ArR: [1, 2, 3]
+map: { foo: 1, bar: 2}
+randomprop: [1, 2, 3]
+)yaml");
+
+        AssertInvalidParseInto<FSimpleStruct>(Yaml, TEXT("Additional properties"), this, {
+            ".randomprop: additional property not match a property in USTRUCT"
+        });
+    }
+
     return !HasAnyErrors();
 }
 

--- a/Source/UnrealYAML/Private/Tests/ConvertToStruct.cpp
+++ b/Source/UnrealYAML/Private/Tests/ConvertToStruct.cpp
@@ -192,7 +192,7 @@ mappedchildren:
         }
 
         TestEqual("ParentChild.MappedChildren", Struct.MappedChildren.Num(), 3);
-        if (TestTrue("ParentChild.MappedChildren", Struct.MappedChildren.Contains(TEnumAsByte(EAnEnum::Value1)))) {
+        if (TestTrue("ParentChild.MappedChildren[value1]", Struct.MappedChildren.Contains(TEnumAsByte(EAnEnum::Value1)))) {
             TestEqual(
                 "ParentChild.MappedChildren[value1].SomeValues",
                 Struct.MappedChildren[TEnumAsByte(EAnEnum::Value1)].SomeValues,
@@ -209,7 +209,7 @@ mappedchildren:
                 TEnumAsByte(EAnEnum::Value1));
         }
 
-        if (TestTrue("ParentChild.MappedChildren", Struct.MappedChildren.Contains(TEnumAsByte(EAnEnum::Value2)))) {
+        if (TestTrue("ParentChild.MappedChildren[value2]", Struct.MappedChildren.Contains(TEnumAsByte(EAnEnum::Value2)))) {
             TestEqual(
                 "ParentChild.MappedChildren[value2].SomeValues",
                 Struct.MappedChildren[TEnumAsByte(EAnEnum::Value2)].SomeValues,
@@ -226,7 +226,7 @@ mappedchildren:
                 TEnumAsByte(EAnEnum::Value2));
         }
 
-        if (TestTrue("ParentChild.MappedChildren", Struct.MappedChildren.Contains(TEnumAsByte(EAnEnum::Value3)))) {
+        if (TestTrue("ParentChild.MappedChildren[value3]", Struct.MappedChildren.Contains(TEnumAsByte(EAnEnum::Value3)))) {
             TestEqual(
                 "ParentChild.MappedChildren[value3].SomeValues",
                 Struct.MappedChildren[TEnumAsByte(EAnEnum::Value3)].SomeValues,
@@ -242,6 +242,29 @@ mappedchildren:
                 Struct.MappedChildren[TEnumAsByte(EAnEnum::Value3)].AnEnum,
                 TEnumAsByte(EAnEnum::Value3));
         }
+    }
+
+    // Tests default are preserved.
+    {
+        FYamlNode Node;
+        UYamlParsing::ParseYaml("{}", Node);
+
+        FDefaultStruct Struct;
+        FYamlParseIntoCtx Result;
+        TestFalse("Default", ParseNodeIntoStruct(Node, Struct, Result));
+
+        TestTrue("Defaults success", Result.Success());
+
+        TestEqual("Default Int", Struct.AnInt, 13);
+        TestEqual("Default Float", Struct.AFloat, 13.24f);
+        TestEqual("Default String", Struct.AString, "Hello world!");
+        TestEqual("Default Enum", Struct.AnEnum, TEnumAsByte(EAnEnum::Value3));
+        if (TestEqual("Default Map", Struct.AMap.Num(), 3)) {
+            TestEqual("Default Map[one]", Struct.AMap["one"], "1");
+            TestEqual("Default Map[two]", Struct.AMap["two"], "2");
+            TestEqual("Default Map[three]", Struct.AMap["three"], "3");
+        }
+        TestEqual("Default Array", Struct.AnArray, {EAnEnum::Value1, EAnEnum::Value2});
     }
 
     return !HasAnyErrors();

--- a/Source/UnrealYAML/Private/Tests/ConvertToStruct.cpp
+++ b/Source/UnrealYAML/Private/Tests/ConvertToStruct.cpp
@@ -8,6 +8,8 @@
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(ConvertToStruct, "UnrealYAML.ConvertToStruct",
                                  EAutomationTestFlags::ApplicationContextMask | EAutomationTestFlags::SmokeFilter)
 
+void AssertSimpleStructValues(ConvertToStruct* TestCase, const FSimpleStruct& SimpleStruct);
+
 bool ConvertToStruct::RunTest(const FString& Parameters) {
     // Simple Yaml
     {
@@ -16,10 +18,34 @@ bool ConvertToStruct::RunTest(const FString& Parameters) {
 
         FSimpleStruct SimpleStruct;
         TestTrue("Parse Node into SimpleStruct", ParseNodeIntoStruct(Node, SimpleStruct));
+        AssertSimpleStructValues(this, SimpleStruct);
+    }
+
+    // CPP non-template ParseIntoStruct
+    {
+        FYamlNode Node;
+        UYamlParsing::ParseYaml(SimpleYaml, Node);
+
+        uint8* StructData = (uint8*)FMemory::Malloc(FSimpleStruct::StaticStruct()->GetStructureSize());
+        FSimpleStruct::StaticStruct()->InitializeDefaultValue(StructData);
+        TestTrue("Parse Node into dynamic SimpleStruct", UYamlParsing::ParseIntoStruct(Node, FSimpleStruct::StaticStruct(), StructData));
+
+        FSimpleStruct* Struct = reinterpret_cast<FSimpleStruct*>(StructData);
+        AssertSimpleStructValues(this, *Struct);
+        FSimpleStruct::StaticStruct()->DestroyStruct(StructData);
     }
 
     return !HasAnyErrors();
 }
 
+void AssertSimpleStructValues(ConvertToStruct* TestCase, const FSimpleStruct& SimpleStruct) {
+    TestCase->TestEqual("SimpleStruct: Str", SimpleStruct.Str, TEXT("A String"));
+    TestCase->TestEqual("SimpleStruct: Int", SimpleStruct.Int, 42);
+    TestCase->TestEqual("SimpleStruct: Bool", SimpleStruct.Bool, true);
+    TestCase->TestEqual("SimpleStruct: Array length", SimpleStruct.Arr.Num(), 3);
+    TestCase->TestEqual("SimpleStruct: Array[0]", SimpleStruct.Arr[0], 1);
+    TestCase->TestEqual("SimpleStruct: Array[1]", SimpleStruct.Arr[1], 2);
+    TestCase->TestEqual("SimpleStruct: Array[2]", SimpleStruct.Arr[2], 3);
+}
 
 #endif

--- a/Source/UnrealYAML/Private/Tests/ConvertToStruct.cpp
+++ b/Source/UnrealYAML/Private/Tests/ConvertToStruct.cpp
@@ -46,6 +46,11 @@ void AssertSimpleStructValues(ConvertToStruct* TestCase, const FSimpleStruct& Si
     TestCase->TestEqual("SimpleStruct: Array[0]", SimpleStruct.Arr[0], 1);
     TestCase->TestEqual("SimpleStruct: Array[1]", SimpleStruct.Arr[1], 2);
     TestCase->TestEqual("SimpleStruct: Array[2]", SimpleStruct.Arr[2], 3);
+    TestCase->TestEqual("SimpleStruct: Map length", SimpleStruct.Map.Num(), 2);
+    TestCase->TestEqual("SimpleStruct: Map contains a", SimpleStruct.Map.Contains("a"), true);
+    TestCase->TestEqual("SimpleStruct: Map value a", SimpleStruct.Map["a"], 1);
+    TestCase->TestEqual("SimpleStruct: Map contains b", SimpleStruct.Map.Contains("b"), true);
+    TestCase->TestEqual("SimpleStruct: Map value b", SimpleStruct.Map["b"], 2);
 }
 
 #endif

--- a/Source/UnrealYAML/Private/Tests/ConvertToStruct.cpp
+++ b/Source/UnrealYAML/Private/Tests/ConvertToStruct.cpp
@@ -175,7 +175,7 @@ mappedchildren:
 
         FParentStruct Struct;
         FYamlParseIntoCtx Result;
-        ParseNodeIntoStruct(Node, Struct, Result);
+        ParseNodeIntoStruct(Node, Struct, Result, FYamlParseIntoOptions::Strict());
 
         TestTrue("ParseInto ParentChild success", Result.Success());
         TestEqual("ParentChild.Embedded.SomeValues", Struct.Embedded.SomeValues, {"one", "two"});
@@ -251,7 +251,7 @@ mappedchildren:
 
         FDefaultStruct Struct;
         FYamlParseIntoCtx Result;
-        TestFalse("Default", ParseNodeIntoStruct(Node, Struct, Result));
+        TestFalse("Default", ParseNodeIntoStruct(Node, Struct, Result, FYamlParseIntoOptions::Strict()));
 
         TestTrue("Default success", Result.Success());
 
@@ -281,7 +281,7 @@ amap:
 
         FDefaultStruct Struct;
         FYamlParseIntoCtx Result;
-        TestFalse("DefaultOverwrite", ParseNodeIntoStruct(Node, Struct, Result));
+        TestFalse("DefaultOverwrite", ParseNodeIntoStruct(Node, Struct, Result, FYamlParseIntoOptions::Strict()));
 
         TestTrue("DefaultOverwrite success", Result.Success());
         TestEqual("DefaultOverwrite Array", Struct.AnArray, {EAnEnum::Value3});
@@ -313,21 +313,21 @@ text: this is some text
 
         FUnrealTypeStruct Struct;
         FYamlParseIntoCtx Result;
-        TestTrue("UnrealTypes", ParseNodeIntoStruct(Node, Struct, Result));
+        TestTrue("UnrealTypes", ParseNodeIntoStruct(Node, Struct, Result, FYamlParseIntoOptions::Strict()));
 
         TestTrue("UnrealTypes success", Result.Success());
 
-        TestEqual("Transform.Location", Struct.Transform.GetLocation(), FVector(1, 2, 3));
-        TestEqual("Transform.Rotation", Struct.Transform.Rotator(), FRotator(0, 0, 90));
-        TestEqual("Transform.Scale", Struct.Transform.GetScale3D(), FVector(2));
-        TestEqual("Quat", Struct.Quat, FQuat::Identity);
-        TestEqual("Rotator", Struct.Rotator, FRotator(90, 0, 180));
-        TestEqual("Vector", Struct.Vector, FVector(13.23, 0, -12.4));
-        TestEqual("Vector2D", Struct.Vector2D, FVector2D(5, 4));
-        TestEqual("Set", Struct.Set.Difference({0, 1, 2, 3, 4}).Num(), 0);
-        TestEqual("LinearColor", Struct.LinearColor, FColor::Red.ReinterpretAsLinear());
-        TestEqual("Color", Struct.Color, FColor::White);
-        TestEqual("Text", Struct.Text.ToString(), "this is some text");
+        TestEqual("UnrealTypes Transform.Location", Struct.Transform.GetLocation(), FVector(1, 2, 3));
+        TestEqual("UnrealTypes Transform.Rotation", Struct.Transform.Rotator(), FRotator(0, 0, 90));
+        TestEqual("UnrealTypes Transform.Scale", Struct.Transform.GetScale3D(), FVector(2));
+        TestEqual("UnrealTypes Quat", Struct.Quat, FQuat::Identity);
+        TestEqual("UnrealTypes Rotator", Struct.Rotator, FRotator(90, 0, 180));
+        TestEqual("UnrealTypes Vector", Struct.Vector, FVector(13.23, 0, -12.4));
+        TestEqual("UnrealTypes Vector2D", Struct.Vector2D, FVector2D(5, 4));
+        TestEqual("UnrealTypes Set", Struct.Set.Difference({0, 1, 2, 3, 4}).Num(), 0);
+        TestEqual("UnrealTypes LinearColor", Struct.LinearColor, FColor::Red.ReinterpretAsLinear());
+        TestEqual("UnrealTypes Color", Struct.Color, FColor::White);
+        TestEqual("UnrealTypes Text", Struct.Text.ToString(), "this is some text");
     }
 
     // Tests negative integers are parsed.

--- a/Source/UnrealYAML/Private/Tests/ConvertToStruct.cpp
+++ b/Source/UnrealYAML/Private/Tests/ConvertToStruct.cpp
@@ -107,7 +107,7 @@ mappedchildren:
         ParseNodeIntoStruct(Node, Struct, Result, FYamlParseIntoOptions::Strict());
 
         TestTrue("Enum parse", Result.Success());
-        TestEqual("Enum parse value", Struct.AnEnum, EAnEnum::Value3);
+        TestEqual("Enum parse value", Struct.AnEnum, EAnEnumClass::Value3);
     }
 
     // Test parsing in to an TEnumAsByte wrapper.
@@ -126,9 +126,9 @@ mappedchildren:
     // Test invalid parsing for enums.
     {
         const auto Yaml = TEXT("anenum: notaknownvalue");
-        const auto Test = TEXT("Invalid EnumAsByte");
+        const auto Test = TEXT("Invalid EnumClass");
         AssertInvalidParseInto<FEnumStruct>(Yaml, Test, this, {
-            ".AnEnum: \"notaknownvalue\" is not an allowed value for enum EAnEnum",
+            ".AnEnum: \"notaknownvalue\" is not an allowed value for enum EAnEnumClass",
         });
     }
 
@@ -264,7 +264,7 @@ mappedchildren:
             TestEqual("Default Map[two]", Struct.AMap["two"], "2");
             TestEqual("Default Map[three]", Struct.AMap["three"], "3");
         }
-        TestEqual("Default Array", Struct.AnArray, {EAnEnum::Value1, EAnEnum::Value2});
+        TestEqual("Default Array", Struct.AnArray, {EAnEnumClass::Value1, EAnEnumClass::Value2});
     }
 
     // Checks that container default values are correctly lost if specified in YAML.
@@ -284,7 +284,7 @@ amap:
         TestFalse("DefaultOverwrite", ParseNodeIntoStruct(Node, Struct, Result, FYamlParseIntoOptions::Strict()));
 
         TestTrue("DefaultOverwrite success", Result.Success());
-        TestEqual("DefaultOverwrite Array", Struct.AnArray, {EAnEnum::Value3});
+        TestEqual("DefaultOverwrite Array", Struct.AnArray, {EAnEnumClass::Value3});
         if (TestEqual("DefaultOverwrite Map", Struct.AMap.Num(), 2)) {
             TestEqual("DefaultOverwrite Map[1]", Struct.AMap["1"], "one");
             TestEqual("DefaultOverwrite Map[2]", Struct.AMap["2"], "two");

--- a/Source/UnrealYAML/Private/Tests/ConvertToStruct.cpp
+++ b/Source/UnrealYAML/Private/Tests/ConvertToStruct.cpp
@@ -441,6 +441,29 @@ randomprop: [1, 2, 3]
         });
     }
 
+    // Tests that custom types can be handled via custom TypeHandlers.
+    {
+        const auto Yaml = TEXT("customtype: 13");
+        FYamlNode Node;
+        UYamlParsing::ParseYaml(Yaml, Node);
+
+        FWithCustomType Struct;
+        FYamlParseIntoCtx Result;
+        auto Options = FYamlParseIntoOptions::Strict();
+        Options.TypeHandlers.Add("FCustomType", [](const FYamlNode& YamlNode, const UScriptStruct* ScriptStruct,
+                                                   void* StructValue, FYamlParseIntoCtx& YamlParseIntoCtx) {
+            auto AsNumber = YamlNode.As<int>();
+            FCustomType Ct;
+            Ct.Value = FString::FromInt(AsNumber);
+            *static_cast<FCustomType*>(StructValue) = Ct;
+        });
+
+        ParseNodeIntoStruct(Node, Struct, Result, Options);
+
+        TestTrue("CustomType: success", Result.Success());
+        TestEqual("CustomType: value", Struct.CustomType.Value, "13");
+    }
+
     return !HasAnyErrors();
 }
 

--- a/Source/UnrealYAML/Private/Tests/ConvertToStruct.cpp
+++ b/Source/UnrealYAML/Private/Tests/ConvertToStruct.cpp
@@ -335,7 +335,7 @@ text: this is some text
         auto Yaml = TEXT(R"yaml(
 subclassOf: "/Script/CoreUObject.Class'/Script/Engine.Actor'"
 
-# Note: this requires loading from disk of a .uasset from the engine content. We assume this is available.
+# Note: this requires loading from disk of a .uasset from engine content. We assume this is available for this test.
 softObjectPtr: "/Script/Engine.StaticMesh'/Engine/BasicShapes/Cube.Cube'"
 )yaml");
 
@@ -353,6 +353,25 @@ softObjectPtr: "/Script/Engine.StaticMesh'/Engine/BasicShapes/Cube.Cube'"
             // Check it's a valid mesh.
             TestTrue("UnrealReferenceTypes TSoftObjectPtr Value", Struct.SoftObjectPtr.LoadSynchronous()->GetNumVertices(0) > 0);
         }
+    }
+
+    // Tests subclassof resolves blueprint classes.
+    {
+        auto Yaml = TEXT(R"yaml(
+# Note: this requires loading from disk of a .uasset from engine content. We assume this is available for this test.
+subclassOf: "/Script/Engine.Blueprint'/Engine/EngineSky/BP_Sky_Sphere.BP_Sky_Sphere'"
+)yaml");
+
+        FYamlNode Node;
+        UYamlParsing::ParseYaml(Yaml, Node);
+
+        FUnrealReferenceTypeStruct Struct;
+        FYamlParseIntoCtx Result;
+        ParseNodeIntoStruct(Node, Struct, Result, FYamlParseIntoOptions::Strict());
+
+        TestTrue("UnrealReferenceTypes success", Result.Success());
+
+        TestTrue("UnrealReferenceTypes TSubclassOf Blueprint", Struct.SubclassOf.Get() != nullptr);
     }
 
     // Unreal reference types fail if the referenced entities cannot be found.

--- a/Source/UnrealYAML/Private/Tests/ConvertToStruct.cpp
+++ b/Source/UnrealYAML/Private/Tests/ConvertToStruct.cpp
@@ -99,15 +99,26 @@ mappedchildren:
         ParseNodeIntoStruct(Node, Struct, Result, FYamlParseIntoOptions::StrictParsing());
 
         TestFalse("Invalid parent child: failed", Result.Success());
-        if (TestEqual("Invalid parent child: errors length", Result.Errors.Num(), 7)) {
+        if (TestEqual("Invalid parent child: errors length", Result.Errors.Num(), 5)) {
             TestEqual("Invalid parent child: errors[0]", Result.Errors[0], TEXT(".Embedded.SomeValues: value is not a sequence"));
             TestEqual("Invalid parent child: errors[1]", Result.Errors[1], TEXT(".Embedded.AFloat: cannot convert \"foobar\" to type float"));
             TestEqual("Invalid parent child: errors[2]", Result.Errors[2], TEXT(".Children.[0]: value is not a map"));
-            TestEqual("Invalid parent child: errors[3]", Result.Errors[3], TEXT(".MappedChildren.value1: cannot convert \"value1\" to type integer"));
-            TestEqual("Invalid parent child: errors[4]", Result.Errors[4], TEXT(".MappedChildren.value1: value is not a map"));
-            TestEqual("Invalid parent child: errors[5]", Result.Errors[5], TEXT(".MappedChildren.value3: cannot convert \"value3\" to type integer"));
-            TestEqual("Invalid parent child: errors[6]", Result.Errors[6], TEXT(".MappedChildren.value3: value is not a map"));
+            TestEqual("Invalid parent child: errors[3]", Result.Errors[3], TEXT(".MappedChildren.value1: value is not a map"));
+            TestEqual("Invalid parent child: errors[4]", Result.Errors[4], TEXT(".MappedChildren.value3: value is not a map"));
         }
+    }
+
+    // Test parsing in to an enum.
+    {
+        FYamlNode Node;
+        UYamlParsing::ParseYaml("anenum: value2", Node);
+
+        FEnumStruct Struct;
+        FYamlParseIntoCtx Result;
+        ParseNodeIntoStruct(Node, Struct, Result, FYamlParseIntoOptions::StrictParsing());
+
+        TestTrue("Enum parse", Result.Success());
+        TestEqual("Enum parse value", Struct.AnEnum, EAnEnum::Value2);
     }
 
     return !HasAnyErrors();

--- a/Source/UnrealYAML/Private/Tests/ConvertToStruct.cpp
+++ b/Source/UnrealYAML/Private/Tests/ConvertToStruct.cpp
@@ -253,7 +253,7 @@ mappedchildren:
         FYamlParseIntoCtx Result;
         TestFalse("Default", ParseNodeIntoStruct(Node, Struct, Result));
 
-        TestTrue("Defaults success", Result.Success());
+        TestTrue("Default success", Result.Success());
 
         TestEqual("Default Int", Struct.AnInt, 13);
         TestEqual("Default Float", Struct.AFloat, 13.24f);
@@ -265,6 +265,30 @@ mappedchildren:
             TestEqual("Default Map[three]", Struct.AMap["three"], "3");
         }
         TestEqual("Default Array", Struct.AnArray, {EAnEnum::Value1, EAnEnum::Value2});
+    }
+
+    // Checks that container default values are correctly lost if specified in YAML.
+    {
+        auto Yaml = TEXT(R"yaml(
+anarray: [value3]
+amap:
+    1: one
+    2: two
+)yaml");
+
+        FYamlNode Node;
+        UYamlParsing::ParseYaml(Yaml, Node);
+
+        FDefaultStruct Struct;
+        FYamlParseIntoCtx Result;
+        TestFalse("DefaultOverwrite", ParseNodeIntoStruct(Node, Struct, Result));
+
+        TestTrue("DefaultOverwrite success", Result.Success());
+        TestEqual("DefaultOverwrite Array", Struct.AnArray, {EAnEnum::Value3});
+        if (TestEqual("DefaultOverwrite Map", Struct.AMap.Num(), 2)) {
+            TestEqual("DefaultOverwrite Map[1]", Struct.AMap["1"], "one");
+            TestEqual("DefaultOverwrite Map[2]", Struct.AMap["2"], "two");
+        }
     }
 
     return !HasAnyErrors();

--- a/Source/UnrealYAML/Private/Tests/TestStructs.h
+++ b/Source/UnrealYAML/Private/Tests/TestStructs.h
@@ -46,10 +46,10 @@ struct FDefaultedStruct {
 };
 
 UENUM()
-enum EAnEnum {
-    Value1,
-    Value2,
-    Value3,
+enum class EAnEnum {
+    Value1 = 0,
+    Value2 = 1,
+    Value3 = 2,
 };
 
 USTRUCT()
@@ -63,7 +63,7 @@ struct FChildStruct {
     float AFloat = -1;
 
     UPROPERTY()
-    TEnumAsByte<EAnEnum> AnEnum = Value3;
+    TEnumAsByte<EAnEnum> AnEnum = EAnEnum::Value3;
 };
 
 USTRUCT()
@@ -81,11 +81,19 @@ struct FParentStruct {
 };
 
 USTRUCT()
-struct FEnumStruct {
+struct FEnumAsByteStruct {
     GENERATED_BODY()
 
     UPROPERTY()
     TEnumAsByte<EAnEnum> AnEnum;
+};
+
+USTRUCT()
+struct FEnumStruct {
+    GENERATED_BODY()
+
+    UPROPERTY()
+    EAnEnum AnEnum;
 };
 
 // Cannot test for complex yaml, as we can't represent mixed nested types :(

--- a/Source/UnrealYAML/Private/Tests/TestStructs.h
+++ b/Source/UnrealYAML/Private/Tests/TestStructs.h
@@ -80,4 +80,12 @@ struct FParentStruct {
     TMap<TEnumAsByte<EAnEnum>, FChildStruct> MappedChildren;
 };
 
+USTRUCT()
+struct FEnumStruct {
+    GENERATED_BODY()
+
+    UPROPERTY()
+    TEnumAsByte<EAnEnum> AnEnum;
+};
+
 // Cannot test for complex yaml, as we can't represent mixed nested types :(

--- a/Source/UnrealYAML/Private/Tests/TestStructs.h
+++ b/Source/UnrealYAML/Private/Tests/TestStructs.h
@@ -166,4 +166,15 @@ struct FUnrealReferenceTypeStruct {
     TSoftObjectPtr<UStaticMesh> SoftObjectPtr;
 };
 
+USTRUCT()
+struct FRequiredFieldsStruct {
+    GENERATED_BODY()
+
+    UPROPERTY(meta=(YamlRequired))
+    int Required;
+
+    UPROPERTY()
+    int Optional;
+};
+
 // Cannot test for complex yaml, as we can't represent mixed nested types :(

--- a/Source/UnrealYAML/Private/Tests/TestStructs.h
+++ b/Source/UnrealYAML/Private/Tests/TestStructs.h
@@ -60,7 +60,7 @@ struct FChildStruct {
     TArray<FString> SomeValues;
 
     UPROPERTY()
-    float AFloat = -1;
+    float AFloat;
 
     UPROPERTY()
     TEnumAsByte<EAnEnum> AnEnum = EAnEnum::Value3;

--- a/Source/UnrealYAML/Private/Tests/TestStructs.h
+++ b/Source/UnrealYAML/Private/Tests/TestStructs.h
@@ -155,4 +155,15 @@ struct FUnrealTypeStruct {
     FText Text;
 };
 
+USTRUCT()
+struct FUnrealReferenceTypeStruct {
+    GENERATED_BODY()
+
+    UPROPERTY()
+    TSubclassOf<AActor> SubclassOf;
+
+    UPROPERTY()
+    TSoftObjectPtr<UStaticMesh> SoftObjectPtr;
+};
+
 // Cannot test for complex yaml, as we can't represent mixed nested types :(

--- a/Source/UnrealYAML/Private/Tests/TestStructs.h
+++ b/Source/UnrealYAML/Private/Tests/TestStructs.h
@@ -123,4 +123,36 @@ struct FDefaultStruct {
     TArray<EAnEnum> AnArray = {EAnEnum::Value1, EAnEnum::Value2};
 };
 
+USTRUCT()
+struct FUnrealTypeStruct {
+    GENERATED_BODY()
+
+    UPROPERTY()
+    FTransform Transform;
+
+    UPROPERTY()
+    FQuat Quat;
+
+    UPROPERTY()
+    FRotator Rotator;
+
+    UPROPERTY()
+    FVector Vector;
+
+    UPROPERTY()
+    FVector2D Vector2D;
+
+    UPROPERTY()
+    TSet<int> Set;
+
+    UPROPERTY()
+    FLinearColor LinearColor;
+
+    UPROPERTY()
+    FColor Color;
+
+    UPROPERTY()
+    FText Text;
+};
+
 // Cannot test for complex yaml, as we can't represent mixed nested types :(

--- a/Source/UnrealYAML/Private/Tests/TestStructs.h
+++ b/Source/UnrealYAML/Private/Tests/TestStructs.h
@@ -24,4 +24,60 @@ struct FSimpleStruct {
     TMap<FString, int32> Map;
 };
 
+// SimpleYaml
+USTRUCT()
+struct FDefaultedStruct {
+    GENERATED_BODY()
+
+    UPROPERTY()
+    FString Str = TEXT("a string");
+
+    UPROPERTY()
+    int32 Int = 1;
+
+    UPROPERTY()
+    bool Bool = true;
+
+    UPROPERTY()
+    TArray<int32> Arr = {1, 2, 3};
+
+    UPROPERTY()
+    TMap<FString, int32> Map = {{"foo", 13}};
+};
+
+UENUM()
+enum EAnEnum {
+    Value1,
+    Value2,
+    Value3,
+};
+
+USTRUCT()
+struct FChildStruct {
+    GENERATED_BODY()
+
+    UPROPERTY()
+    TArray<FString> SomeValues;
+
+    UPROPERTY()
+    float AFloat = -1;
+
+    UPROPERTY()
+    TEnumAsByte<EAnEnum> AnEnum = Value3;
+};
+
+USTRUCT()
+struct FParentStruct {
+    GENERATED_BODY()
+
+    UPROPERTY()
+    FChildStruct Embedded;
+
+    UPROPERTY()
+    TArray<FChildStruct> Children;
+
+    UPROPERTY()
+    TMap<TEnumAsByte<EAnEnum>, FChildStruct> MappedChildren;
+};
+
 // Cannot test for complex yaml, as we can't represent mixed nested types :(

--- a/Source/UnrealYAML/Private/Tests/TestStructs.h
+++ b/Source/UnrealYAML/Private/Tests/TestStructs.h
@@ -177,4 +177,19 @@ struct FRequiredFieldsStruct {
     int Optional;
 };
 
+USTRUCT()
+struct FCustomType {
+    GENERATED_BODY()
+
+    FString Value;
+};
+
+USTRUCT()
+struct FWithCustomType {
+    GENERATED_BODY()
+
+    UPROPERTY()
+    FCustomType CustomType;
+};
+
 // Cannot test for complex yaml, as we can't represent mixed nested types :(

--- a/Source/UnrealYAML/Private/Tests/TestStructs.h
+++ b/Source/UnrealYAML/Private/Tests/TestStructs.h
@@ -46,7 +46,14 @@ struct FDefaultedStruct {
 };
 
 UENUM()
-enum class EAnEnum {
+enum EAnEnum {
+    Value1 = 0,
+    Value2 = 1,
+    Value3 = 2,
+};
+
+UENUM()
+enum class EAnEnumClass : uint8 {
     Value1 = 0,
     Value2 = 1,
     Value3 = 2,
@@ -93,7 +100,7 @@ struct FEnumStruct {
     GENERATED_BODY()
 
     UPROPERTY()
-    EAnEnum AnEnum;
+    EAnEnumClass AnEnum;
 };
 
 USTRUCT()
@@ -120,7 +127,7 @@ struct FDefaultStruct {
     };
 
     UPROPERTY()
-    TArray<EAnEnum> AnArray = {EAnEnum::Value1, EAnEnum::Value2};
+    TArray<EAnEnumClass> AnArray = {EAnEnumClass::Value1, EAnEnumClass::Value2};
 };
 
 USTRUCT()

--- a/Source/UnrealYAML/Private/Tests/TestStructs.h
+++ b/Source/UnrealYAML/Private/Tests/TestStructs.h
@@ -96,4 +96,31 @@ struct FEnumStruct {
     EAnEnum AnEnum;
 };
 
+USTRUCT()
+struct FDefaultStruct {
+    GENERATED_BODY()
+
+    UPROPERTY()
+    int AnInt = 13;
+
+    UPROPERTY()
+    float AFloat = 13.24;
+
+    UPROPERTY()
+    FString AString = "Hello world!";
+
+    UPROPERTY()
+    TEnumAsByte<EAnEnum> AnEnum = EAnEnum::Value3;
+
+    UPROPERTY()
+    TMap<FString, FString> AMap = {
+        {"one", "1"},
+        {"two", "2"},
+        {"three", "3"},
+    };
+
+    UPROPERTY()
+    TArray<EAnEnum> AnArray = {EAnEnum::Value1, EAnEnum::Value2};
+};
+
 // Cannot test for complex yaml, as we can't represent mixed nested types :(

--- a/Source/UnrealYAML/Public/Node.h
+++ b/Source/UnrealYAML/Public/Node.h
@@ -226,6 +226,20 @@ public:
         Node.force_insert(Key, Value);
     }
 
+    /** Returns all keys if this node is a map, otherwise an empty set */
+    template<typename T>
+    TSet<T> Keys() const {
+        TSet<T> Ret;
+        if (!IsMap()) return Ret;
+        for (const auto Entry : Node) {
+            T Key;
+            if (YAML::convert<T>::decode(Entry.first, Key)) {
+                Ret.Add(Entry.first.as<T>());
+            }
+        }
+        return Ret;
+    }
+
     // Indexing ------------------------------------------------------------------------
     /** Returns the Value at the given Key or Index */
     template<typename T>

--- a/Source/UnrealYAML/Public/Parsing.h
+++ b/Source/UnrealYAML/Public/Parsing.h
@@ -60,6 +60,9 @@ struct UNREALYAML_API FYamlParseIntoOptions {
     UPROPERTY()
     bool CheckAdditionalProperties = false;
 
+    typedef TFunction<void (const FYamlNode& Node, const UScriptStruct* Struct, void* StructValue,
+                                  struct FYamlParseIntoCtx& Ctx)> FTypeHandler;
+
     /**
      * Define ParseInto handling for your own types here. By default, ParseIntoStruct will handle
      * some common Unreal types (see ParseIntoNativeType). This allows for defining additional types
@@ -72,8 +75,7 @@ struct UNREALYAML_API FYamlParseIntoOptions {
      * The provided StructValue is a pointer where the new value must be set. See ParseIntoNativeType
      * for examples of how this ptr is converted to a typed ptr, then the value set.
      */
-    TMap<FString, TFunction<void (const FYamlNode& Node, const UScriptStruct* Struct, void* StructValue,
-                                  struct FYamlParseIntoCtx& Ctx)>> TypeHandlers;
+    TMap<FString, FTypeHandler> TypeHandlers;
 };
 
 /**

--- a/Source/UnrealYAML/Public/Parsing.h
+++ b/Source/UnrealYAML/Public/Parsing.h
@@ -59,6 +59,21 @@ struct UNREALYAML_API FYamlParseIntoOptions {
      */
     UPROPERTY()
     bool CheckAdditionalProperties = false;
+
+    /**
+     * Define ParseInto handling for your own types here. By default, ParseIntoStruct will handle
+     * some common Unreal types (see ParseIntoNativeType). This allows for defining additional types
+     * that need some special handling.
+     *
+     * The key is the CPP type name, and the associated function is responsible for interpreting the
+     * given node, constructing the custom type, then setting it given in StructValue. Any
+     * errors encountered can be added to Ctx.
+     *
+     * The provided StructValue is a pointer where the new value must be set. See ParseIntoNativeType
+     * for examples of how this ptr is converted to a typed ptr, then the value set.
+     */
+    TMap<FString, TFunction<void (const FYamlNode& Node, const UScriptStruct* Struct, void* StructValue,
+                                  struct FYamlParseIntoCtx& Ctx)>> TypeHandlers;
 };
 
 /**

--- a/Source/UnrealYAML/Public/Parsing.h
+++ b/Source/UnrealYAML/Public/Parsing.h
@@ -67,7 +67,7 @@ struct UNREALYAML_API FYamlParseIntoOptions {
      *
      * The key is the CPP type name, and the associated function is responsible for interpreting the
      * given node, constructing the custom type, then setting it given in StructValue. Any
-     * errors encountered can be added to Ctx.
+     * errors encountered can be added to Ctx with Ctx.AddError.
      *
      * The provided StructValue is a pointer where the new value must be set. See ParseIntoNativeType
      * for examples of how this ptr is converted to a typed ptr, then the value set.
@@ -103,6 +103,8 @@ struct UNREALYAML_API FYamlParseIntoCtx {
 
     friend class UYamlParsing;
 
+    void AddError(const TCHAR* Err);
+
 private:
 
     // Stack access.
@@ -110,8 +112,6 @@ private:
     FYamlParseIntoCtx& PushStack(const FYamlNode& Key);
     FYamlParseIntoCtx& PushStack(const int32 Index);
     void PopStack();
-
-    void AddError(const TCHAR* Err);
 
     TArray<FString> Stack = {TEXT("")};
     FString StackStr() const;

--- a/Source/UnrealYAML/Public/Parsing.h
+++ b/Source/UnrealYAML/Public/Parsing.h
@@ -45,6 +45,13 @@ struct UNREALYAML_API FYamlParseIntoOptions {
      */
     UPROPERTY()
     bool CheckEnums = false;
+
+    /**
+     * Inspects fields' UPROPERTY meta for a "YamlRequired" specifier on the USTRUCT being parsed in to.
+     * If present, and an incoming YAML structure is missing this property, a validation error will occur.
+     */
+    UPROPERTY()
+    bool CheckRequired = false;
 };
 
 /**
@@ -104,6 +111,10 @@ class UNREALYAML_API UYamlParsing final : public UBlueprintFunctionLibrary {
     // of the Parsing all Fields further (basically a shortcut with neater results). This is only used to determine *if* an
     // FProperty can be converted directly, the if-else chain to check what type it actually is, is in ParseIntoNativeType itself.
     const static TArray<FString> NativeTypes;
+
+    // UPROPERTY(meta=YamlRequired) indicates a USTRUCT's property is required when parsing in to it
+    // from a YAML node. This is the string we look for.
+    inline const static FName YamlRequiredSpecifier = FName(TEXT("YamlRequired"));
 
 public:
     // Parsing of Strings/Files into Nodes -----------------------------------------------------------------------------

--- a/Source/UnrealYAML/Public/Parsing.h
+++ b/Source/UnrealYAML/Public/Parsing.h
@@ -13,7 +13,7 @@ DECLARE_LOG_CATEGORY_EXTERN(LogYamlParsing, Log, All)
  * The default values here preserve previous behaviour before Options was introduced.
  */
 USTRUCT()
-struct FYamlParseIntoOptions {
+struct UNREALYAML_API FYamlParseIntoOptions {
     GENERATED_BODY()
 
     // Static factory for a set of options that enforces validity of the incoming YAML.
@@ -52,7 +52,7 @@ struct FYamlParseIntoOptions {
  * once parsing is complete.
  */
 USTRUCT()
-struct FYamlParseIntoCtx {
+struct UNREALYAML_API FYamlParseIntoCtx {
     GENERATED_BODY()
 
     /**

--- a/Source/UnrealYAML/Public/Parsing.h
+++ b/Source/UnrealYAML/Public/Parsing.h
@@ -86,15 +86,18 @@ public:
         }
     }
 
+    /** Parse the given YAML in to a struct whose type is not known at compile time. This is useful
+     * when dealing with struct of an unknown types in CPP contexts, such as interacting with Unreal's
+     * data tables.
+     */
+    static bool ParseIntoStruct(const FYamlNode& Node, const UScriptStruct* Struct, void* StructValue);
+
 private:
     // Parses a Node into a Single Property. Can be a FStructProperty itself (recursion!)
     static bool ParseIntoProperty(const FYamlNode& Node, const FProperty& Property, void* PropertyValue);
 
     // Parses a Node into a Single UObject. Calls ParseIntoProperty on all Fields
     static bool ParseIntoObject(const FYamlNode& Node, const UClass* Object, void* ObjectValue);
-
-    // Parses a Node into a Single Struct. Calls ParseIntoProperty on all Fields
-    static bool ParseIntoStruct(const FYamlNode& Node, const UScriptStruct* Struct, void* StructValue);
 
     // Parses a Node via some predefined conversions in UnrealTypes.h via a switch case (see NativeTypes).
     static bool ParseIntoNativeType(const FYamlNode& Node, const UScriptStruct* Struct, void* StructValue);

--- a/Source/UnrealYAML/Public/Parsing.h
+++ b/Source/UnrealYAML/Public/Parsing.h
@@ -56,6 +56,10 @@ struct FYamlParseIntoCtx {
      */
     bool Success() const;
 
+    friend class UYamlParsing;
+
+private:
+
     // Stack access.
     FYamlParseIntoCtx& PushStack(const TCHAR* Property);
     FYamlParseIntoCtx& PushStack(const FYamlNode& Key);
@@ -64,7 +68,6 @@ struct FYamlParseIntoCtx {
 
     void AddError(const TCHAR* Err);
 
-private:
     TArray<FString> Stack = {TEXT("")};
     FString StackStr() const;
 };

--- a/Source/UnrealYAML/Public/Parsing.h
+++ b/Source/UnrealYAML/Public/Parsing.h
@@ -201,6 +201,27 @@ private:
     static bool CheckNodeType(FYamlParseIntoCtx& Ctx, const EYamlNodeType Expected, const TCHAR* TypeName, const FYamlNode& Node);
 
     static bool CheckEnumValue(FYamlParseIntoCtx& Ctx, const FYamlNode& Node, const UEnum* Enum);
+
+    // Resolves a UObject by its path, or nullptr if not found.
+    template <typename BaseClass>
+    static UObject* FindObject(const FString& Path) {
+        return StaticLoadObject(BaseClass::StaticClass(), nullptr, *Path);
+    }
+
+    // Resolve a class by its path, including blueprint classes. Nullptr if not found.
+    static UClass* FindClass(const FString& Path) {
+        auto Obj = StaticLoadClass(UObject::StaticClass(), nullptr, *Path);
+        if (IsValid(Obj)) {
+            return Obj;
+        }
+
+        auto Bp = Cast<UBlueprint>(FindObject<UBlueprint>(Path));
+        if (!Bp) {
+            return nullptr;
+        }
+
+        return Cast<UClass>(Bp->GeneratedClass);
+    }
 };
 
 

--- a/Source/UnrealYAML/Public/Parsing.h
+++ b/Source/UnrealYAML/Public/Parsing.h
@@ -52,6 +52,13 @@ struct UNREALYAML_API FYamlParseIntoOptions {
      */
     UPROPERTY()
     bool CheckRequired = false;
+
+    /**
+     * If true, validation will fail if the YAML contains properties that do not match with
+     * a property in the struct being parsed.
+     */
+    UPROPERTY()
+    bool CheckAdditionalProperties = false;
 };
 
 /**

--- a/Source/UnrealYAML/yaml-cpp/src/emitterstate.cpp
+++ b/Source/UnrealYAML/yaml-cpp/src/emitterstate.cpp
@@ -107,10 +107,6 @@ EmitterNodeType EmitterState::NextGroupType(
   if (GetFlowType(type) == EmitterManip::Block)
     return EmitterNodeType::BlockMap;
   return EmitterNodeType::FlowMap;
-
-  // can't happen
-  assert(false);
-  return EmitterNodeType::NoType;
 }
 
 void EmitterState::StartedDoc() {

--- a/Source/UnrealYAML/yaml-cpp/src/emitterstate.h
+++ b/Source/UnrealYAML/yaml-cpp/src/emitterstate.h
@@ -175,10 +175,6 @@ class EmitterState {
         else
           return EmitterNodeType::BlockMap;
       }
-
-      // can't get here
-      assert(false);
-      return EmitterNodeType::NoType;
     }
   };
 


### PR DESCRIPTION
Adds extra functionality, primarily around parsing YAML nodes in to Unreal structs.

* Expose CPP methods for parsing a struct's types only known at runtime.
* Support for new types in `ParseIntoStruct`:
  * `TMap`
  * `TSoftObjectPtr`
  * `TSubclassOf`
  * `FVector2D`
  * `FRotator`
* Values from YAML when parsed into container properties (e.g. `TArray`) with a default value now correctly overwrite any default values.
* Extends the existing API for struct parsing with:
  * An options object, optionally enabling new functionality.
  * An optional results object. Callers can inspect this for more detail of new validation failures.
  * I've tried to preserve the existing API (a `bool` return denoting all properties being parsed), and added overloads for using the new options/result features. Similarly, the BP API should behave exactly as before, though I haven't tested this.
* These new validation features are described in the [README](https://github.com/vaeryn-uk/UnrealYAML/pull/1/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R21)
* Negative integers can now be parsed in to a struct.
* Tests for the above, and some additional coverage for existing functionality.

Additionally a compatibility tweak for UE5.4. Removed some unreachable code in `yaml-cpp`.